### PR TITLE
moving from pgvector to FLOAT8[]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ backend/uploads/
 backend/vault.db
 backend/.env
 backend/credentials.js
+backend/storage/

--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -1,71 +1,89 @@
-const RAGPipelineService = require('../services/RAGPipelineService');
+// backend/controllers/chatController.js - DIRECT LINK TO SEARCH SERVICE
+// --------------------------------------------------------
+// [REFACTOR] Bypasses RAGPipelineService to directly use the fixed searchService.
+// [COMPATIBILITY] Simulates Socket.io streaming events so Frontend accepts the response.
+// --------------------------------------------------------
+
+const { performRAG } = require('../searchService'); // Use the fixed service
 const ChatHistoryService = require('../services/ChatHistoryService');
 const logger = require('../utils/logger');
 
 const SERVICE_NAME = 'chatController';
 
 /**
- * [MODIFIED] Handles the ASYNCHRONOUS streaming chat query.
- * Extracts the required chatMode parameter.
+ * [MODIFIED] Handles the chat query by calling searchService directly.
+ * Simulates streaming events to maintain frontend compatibility.
  */
-exports.handleChatQuery = (req, res) => {
+exports.handleChatQuery = async (req, res) => {
     const { roomId, conversationId } = req.params;
-    const { query, socketId, chatMode } = req.body; 
+    const { query, socketId, chatMode } = req.body;
     const userId = req.user.id;
-    const userRole = req.user.role;
-    const reqSocketServer = req.io; // The Socket.io server instance
-    
-    // Validate chatMode to ensure it's one of our defined tiers
+    const reqSocketServer = req.io;
+
+    // Default to 'STANDARD' if mode is invalid
     const validModes = ['STANDARD', 'DEEP_THINK', 'DEEP_RESEARCH'];
     const finalChatMode = chatMode && validModes.includes(chatMode) ? chatMode : 'STANDARD';
 
     logger.info(SERVICE_NAME, `[START] POST /${roomId}/${conversationId} for user ${userId}`);
-    logger.debug(SERVICE_NAME, `Body: { query: "${query ? query.substring(0, 20) : 'NULL'}...", socketId: ${socketId}, mode: ${finalChatMode} }`);
 
     // --- 1. Validation ---
     if (!query || !socketId || !reqSocketServer) {
-        logger.warn(SERVICE_NAME, 'Validation failed: Missing query, socketId, or socket server.');
         return res.status(400).json({ message: 'Missing required query or streaming context.' });
     }
-    
-    // --- 2. Find the specific user's socket ---
+
     const socket = reqSocketServer.sockets.sockets.get(socketId);
     if (!socket) {
-        logger.error(SERVICE_NAME, `Validation failed: Socket ID ${socketId} not found or disconnected.`);
         return res.status(404).json({ message: 'Client socket not found. Please reconnect.' });
     }
 
-    // --- 3. Define the unique event name for this response ---
     const responseEventName = `chat_response_${conversationId}`;
 
-    // --- 4. Trigger the RAG pipeline (FIRE-AND-FORGET) ---
-    logger.info(SERVICE_NAME, `Triggering async RAGPipelineService. Mode: ${finalChatMode}`);
-    
-    // [ASYNC EXECUTION] We do NOT await this. 
-    // The pipeline runs in the background and emits events via Socket.io
-    RAGPipelineService.handleUserQuery({
-        query,
-        chatMode: finalChatMode,
-        userId,
-        userRole,
-        roomId,
-        conversationId,
-        socket,
-        responseEventName
-    }).catch(pipelineError => {
-        logger.error(SERVICE_NAME, `[FATAL] RAG Pipeline boot-up failed for convo ${conversationId}:`, pipelineError);
-        socket.emit(responseEventName, {
-            type: 'error',
-            data: { message: 'A fatal error occurred while starting the pipeline.' }
-        });
-    });
-
-    // --- 5. Immediately send the HTTP 202 Accepted response ---
-    logger.info(SERVICE_NAME, `[END] Sending 202 Accepted. Event: ${responseEventName}`);
+    // --- 2. Send Immediate HTTP 202 (Accepted) ---
+    // This tells the frontend "We got it, listen to the socket now"
     res.status(202).json({
-        message: 'Query received. Processing... Listen for streaming response.',
+        message: 'Query received. Processing...',
         eventName: responseEventName
     });
+
+    // --- 3. Async Execution (The "Pipeline") ---
+    // We run this in the background so the HTTP request completes fast
+    (async () => {
+        try {
+            logger.info(SERVICE_NAME, `[ASYNC] Starting RAG for convo ${conversationId}...`);
+
+            // Notify Frontend: "We are thinking..."
+            socket.emit(responseEventName, { type: 'start' });
+            socket.emit(responseEventName, { type: 'thinking', data: 'Searching documents...' });
+
+            // A. Perform RAG (Retrieval + Generation)
+            // This calls our new Node-side logic in searchService.js
+            const result = await performRAG(userId, query, [], conversationId, roomId);
+
+            // B. Simulate Streaming (Send the full answer as one chunk)
+            // Since we aren't streaming token-by-token, we send the whole block.
+            // The frontend should append this chunk to the UI.
+            if (result.answer) {
+                socket.emit(responseEventName, {
+                    type: 'chunk',
+                    data: result.answer
+                });
+            }
+
+            // C. Finish
+            logger.info(SERVICE_NAME, `[ASYNC] RAG Complete. Sending done signal.`);
+            socket.emit(responseEventName, {
+                type: 'done',
+                data: { sources: result.sources || [] }
+            });
+
+        } catch (error) {
+            logger.error(SERVICE_NAME, `[FATAL] RAG failed for convo ${conversationId}:`, error.message);
+            socket.emit(responseEventName, {
+                type: 'error',
+                data: { message: 'An error occurred while processing your request.' }
+            });
+        }
+    })();
 };
 
 /**
@@ -75,10 +93,9 @@ exports.createConversation = async (req, res) => {
     const { roomId } = req.params;
     const userId = req.user.id;
     logger.info(SERVICE_NAME, `POST /${roomId}/new for user ${userId}`);
-    
+
     try {
         const newConversation = await ChatHistoryService.createConversation(userId, roomId);
-        logger.info(SERVICE_NAME, `Conversation ${newConversation.conversation_id} created.`);
         res.status(201).json(newConversation);
     } catch (error) {
         logger.error(SERVICE_NAME, `Failed to create conversation in room ${roomId}`, error);
@@ -92,13 +109,12 @@ exports.createConversation = async (req, res) => {
 exports.getConversations = async (req, res) => {
     const { roomId } = req.params;
     const userId = req.user.id;
-    logger.info(SERVICE_NAME, `GET /${roomId} for user ${userId}`);
 
     try {
         const conversations = await ChatHistoryService.getConversations(userId, roomId);
         res.status(200).json(conversations);
     } catch (error) {
-        logger.error(SERVICE_NAME, `Failed to get conversations for user ${userId} in room ${roomId}`, error);
+        logger.error(SERVICE_NAME, `Failed to get conversations`, error);
         res.status(500).json({ message: 'Error fetching conversations.' });
     }
 };
@@ -109,17 +125,14 @@ exports.getConversations = async (req, res) => {
 exports.getConversationHistory = async (req, res) => {
     const { conversationId } = req.params;
     const userId = req.user.id;
-    logger.info(SERVICE_NAME, `GET /history/${conversationId} for user ${userId}`);
-    
+
     try {
         const history = await ChatHistoryService.getConversationHistory(userId, conversationId);
         res.status(200).json(history);
     } catch (error) {
         if (error.message === 'Access denied') {
-            logger.warn(SERVICE_NAME, `Access denied for user ${userId} on convo ${conversationId}`);
             return res.status(403).json({ message: 'Access denied.' });
         }
-        logger.error(SERVICE_NAME, `Failed to get history for convo ${conversationId}`, error);
         res.status(500).json({ message: 'Error fetching history.' });
     }
 };
@@ -130,14 +143,12 @@ exports.getConversationHistory = async (req, res) => {
 exports.deleteConversation = async (req, res) => {
     const { conversationId } = req.params;
     const userId = req.user.id;
-    logger.info(SERVICE_NAME, `DELETE /${conversationId} for user ${userId}`);
 
     try {
         const result = await ChatHistoryService.deleteConversation(userId, conversationId);
         if (!result.success) {
             return res.status(404).json({ message: result.message });
         }
-        logger.info(SERVICE_NAME, `Successfully deleted convo ${conversationId}`);
         res.status(204).send();
     } catch (error) {
         logger.error(SERVICE_NAME, `Failed to delete conversation ${conversationId}`, error);
@@ -145,23 +156,19 @@ exports.deleteConversation = async (req, res) => {
     }
 };
 
-
 /**
  * [NEW] Searches conversation history across all rooms for a user.
  */
 exports.searchChatHistory = async (req, res) => {
     const { q: searchTerm } = req.query;
     const userId = req.user.id;
-    logger.info(SERVICE_NAME, `GET /search for user ${userId} with term: "${searchTerm}"`);
 
     if (!searchTerm || searchTerm.length < 3) {
-        logger.warn(SERVICE_NAME, 'Search term too short or missing.');
         return res.status(400).json({ message: 'Search term must be at least 3 characters.' });
     }
-    
+
     try {
         const results = await ChatHistoryService.searchChatHistory(userId, searchTerm);
-        logger.info(SERVICE_NAME, `Found ${results.length} grouped search results.`);
         res.status(200).json(results);
     } catch (error) {
         logger.error(SERVICE_NAME, `Failed to run search for user ${userId}`, error);

--- a/backend/database.js
+++ b/backend/database.js
@@ -1,20 +1,24 @@
-// backend/database.js - ENTERPRISE SANITIZATION ADDED
+// backend/database.js - ENTERPRISE POSTGRES (NO-PLUGIN VERSION)
+// --------------------------------------------------------
+// [SCALABILITY] Uses PostgreSQL but replaces 'vector' extension 
+// with standard FLOAT8[] arrays to avoid Windows installation errors.
+// --------------------------------------------------------
 
-const { Pool } = require('pg'); 
+const { Pool } = require('pg');
 require('dotenv').config();
 const crypto = require('crypto');
-const logger = require('./utils/logger'); 
+const logger = require('./utils/logger');
 
-let pool = null; 
+let pool = null;
 
 // --- CONFIGURATION ---
 const PG_CONFIG = {
-    user: process.env.PG_USER,
-    host: process.env.PG_HOST,
-    database: process.env.PG_DATABASE,
-    password: process.env.PG_PASSWORD,
+    user: process.env.PG_USER || 'postgres',
+    host: process.env.PG_HOST || 'localhost',
+    database: process.env.PG_DATABASE || 'postgres',
+    password: process.env.PG_PASSWORD || 'root',
     port: process.env.PG_PORT || 5432,
-    max: 20, 
+    max: 20,
     idleTimeoutMillis: 30000,
     connectionTimeoutMillis: 2000,
 };
@@ -72,7 +76,7 @@ const executeTransaction = async (callback) => {
 };
 
 // --- UTILS ---
-const generateRoomCode = () => crypto.randomBytes(3).toString('hex').toUpperCase(); 
+const generateRoomCode = () => crypto.randomBytes(3).toString('hex').toUpperCase();
 
 const backfillRoomCodes = async () => {
     logger.info('DB_ALTER', '[Backfill] Checking for NULL room_codes...');
@@ -80,8 +84,8 @@ const backfillRoomCodes = async () => {
         const client = await getPool().connect();
         const res = await client.query('SELECT id FROM chat_rooms WHERE room_code IS NULL');
         if (res.rows.length > 0) {
-             logger.info('DB_ALTER', `Backfilling ${res.rows.length} rooms...`);
-             for (const row of res.rows) {
+            logger.info('DB_ALTER', `Backfilling ${res.rows.length} rooms...`);
+            for (const row of res.rows) {
                 let unique = false;
                 let newCode;
                 while (!unique) {
@@ -90,8 +94,8 @@ const backfillRoomCodes = async () => {
                     if (check.rowCount === 0) unique = true;
                 }
                 await client.query('UPDATE chat_rooms SET room_code = $1 WHERE id = $2', [newCode, row.id]);
-             }
-             logger.info('DB_ALTER_SUCCESS', `Backfill complete.`);
+            }
+            logger.info('DB_ALTER_SUCCESS', `Backfill complete.`);
         }
         client.release();
     } catch (error) {
@@ -115,19 +119,19 @@ const seedRoleDefinitions = async (client) => {
 
 // --- INITIALIZATION ---
 const initializeDatabase = async () => {
-    const dbPool = getPool(); 
+    const dbPool = getPool();
     const client = await dbPool.connect();
     try {
         logger.info('DB_INIT', 'Starting Schema Initialization...');
-        
-        await client.query('CREATE EXTENSION IF NOT EXISTS vector'); 
-        await client.query('CREATE EXTENSION IF NOT EXISTS pg_trgm'); 
-        
+
+        // [FIX] Removed 'vector' extension check to allow standard Postgres usage
+        await client.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+
         const createTable = async (name, schema) => {
             await client.query(schema);
             logger.info('DB_INIT', `Table '${name}' verified.`);
         };
-        
+
         // 1. Roles
         await createTable('role_definitions', `
             CREATE TABLE IF NOT EXISTS role_definitions (
@@ -169,15 +173,15 @@ const initializeDatabase = async () => {
                 manager_id INTEGER REFERENCES users(id) ON DELETE SET NULL
             )
         `);
-        
+
         // Role Migration
         logger.info('DB_MIGRATE', 'Checking for legacy role names...');
         for (const role of CORE_ROLES) {
             try {
                 await client.query(`UPDATE users SET role = $1 WHERE role = $2`, [role.key, role.default_display]);
-            } catch (migErr) {}
+            } catch (migErr) { }
         }
-        
+
         // 4. Clients
         await createTable('clients', `
             CREATE TABLE IF NOT EXISTS clients (
@@ -198,7 +202,7 @@ const initializeDatabase = async () => {
                 UNIQUE(admin_id, client_id)
             )
         `);
-        
+
         // 6. Chat Rooms
         await createTable('chat_rooms', `
             CREATE TABLE IF NOT EXISTS chat_rooms (
@@ -213,14 +217,14 @@ const initializeDatabase = async () => {
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )
         `);
-        
+
         // 7-10. Room Assignments
         const assignmentTables = ['room_client_assignments', 'room_admin_assignments', 'room_po_assignments', 'room_user_assignments'];
         const idCols = ['client_id', 'admin_id', 'po_id', 'user_id'];
         const refs = ['clients(id)', 'users(id)', 'users(id)', 'users(id)'];
 
         for (let i = 0; i < assignmentTables.length; i++) {
-             await createTable(assignmentTables[i], `
+            await createTable(assignmentTables[i], `
                 CREATE TABLE IF NOT EXISTS ${assignmentTables[i]} (
                     id SERIAL PRIMARY KEY,
                     room_id INTEGER NOT NULL REFERENCES chat_rooms(id) ON DELETE CASCADE,
@@ -247,7 +251,7 @@ const initializeDatabase = async () => {
             )
         `);
 
-        // 12. Product Access Requests (Peer JIT)
+        // 12-13. Other Access Requests
         await createTable('product_access_requests', `
             CREATE TABLE IF NOT EXISTS product_access_requests (
                 id SERIAL PRIMARY KEY,
@@ -263,7 +267,6 @@ const initializeDatabase = async () => {
             )
         `);
 
-        // 13. Client Access Requests (Peer JIT)
         await createTable('client_access_requests', `
             CREATE TABLE IF NOT EXISTS client_access_requests (
                 id SERIAL PRIMARY KEY,
@@ -301,8 +304,8 @@ const initializeDatabase = async () => {
                 uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )
         `);
-        
-        // 16. Document Chunks (pgvector)
+
+        // 16. Document Chunks (FLOAT8[] instead of VECTOR)
         await createTable('document_chunks', `
             CREATE TABLE IF NOT EXISTS document_chunks (
                 id SERIAL PRIMARY KEY,
@@ -311,12 +314,12 @@ const initializeDatabase = async () => {
                 chunk_id TEXT NOT NULL, 
                 content TEXT NOT NULL,
                 page_number INTEGER,
-                embedding VECTOR(${process.env.EMBEDDING_DIMENSION || 384}), 
+                embedding FLOAT8[], 
                 created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE(document_id, chunk_id)
             )
         `);
-        
+
         // 17. Conversations
         await createTable('conversations', `
             CREATE TABLE IF NOT EXISTS conversations (
@@ -339,12 +342,12 @@ const initializeDatabase = async () => {
                 timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
             )
         `);
-        
+
         // 19. Indexes
         await client.query(`CREATE INDEX IF NOT EXISTS trgm_idx_chat_message ON chat_history USING GIN (message gin_trgm_ops)`);
 
-        await backfillRoomCodes(); 
-        logger.info('DB_INIT_FINAL', 'All PostgreSQL schemas and extensions verified.');
+        await backfillRoomCodes();
+        logger.info('DB_INIT_FINAL', 'All PostgreSQL schemas verified (Standard Arrays).');
 
     } catch (err) {
         logger.error('DB_INIT_FATAL', 'Schema Initialization Failed:', err.message);
@@ -354,23 +357,20 @@ const initializeDatabase = async () => {
     }
 };
 
-// --- ATOMIC SAVE FUNCTION (ENTERPRISE SANITIZATION) ---
+// --- ATOMIC SAVE FUNCTION (PG ARRAY ADAPTER) ---
 async function saveDocumentChunks(userId, originalName, filePath, chunksWithVectors, roomId) {
     logger.info('saveDocumentChunks', `[PG_TX_START] Atomic save for: ${originalName}`);
-    
-    // [SANITIZATION] Filter out chunks that are null, undefined, empty strings, or just whitespace.
-    // This prevents the "null value in column content" error from PostgreSQL.
+
+    // [SANITIZATION]
     const chunksToInsert = chunksWithVectors.filter(c => {
         const hasVector = c.vector && c.vector.length > 0;
         const hasContent = c.content && typeof c.content === 'string' && c.content.trim().length > 0;
-        
         if (!hasContent && hasVector) {
             logger.warn('saveDocumentChunks', `[SANITIZATION] Dropping chunk ${c.id} (Valid Vector, NULL/Empty Content).`);
         }
-        
         return hasVector && hasContent;
     });
-    
+
     logger.info('saveDocumentChunks', `[SANITIZATION] ${chunksWithVectors.length} chunks in -> ${chunksToInsert.length} valid chunks out.`);
 
     return executeTransaction(async (client) => {
@@ -379,17 +379,17 @@ async function saveDocumentChunks(userId, originalName, filePath, chunksWithVect
             [userId, roomId, originalName, filePath]
         );
         const documentId = docRes.rows[0].id;
-        
+
         if (chunksToInsert.length > 0) {
             const chunkValues = [];
             const chunkPlaceholders = [];
             let idx = 1;
-            
+
             chunksToInsert.forEach((chunk, i) => {
                 const chunkId = `${documentId}-${i}-${crypto.randomBytes(4).toString('hex')}`;
-                const vecStr = `[${chunk.vector.join(',')}]`;
-                chunkValues.push(chunkId, documentId, roomId, chunk.content, chunk.page_number, vecStr);
-                chunkPlaceholders.push(`($${idx}, $${idx+1}, $${idx+2}, $${idx+3}, $${idx+4}, $${idx+5})`);
+                // Standard PG arrays don't need string formatting like vector('[...]'), just pass the array
+                chunkValues.push(chunkId, documentId, roomId, chunk.content, chunk.page_number, chunk.vector);
+                chunkPlaceholders.push(`($${idx}, $${idx + 1}, $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5})`);
                 idx += 6;
             });
 
@@ -399,9 +399,9 @@ async function saveDocumentChunks(userId, originalName, filePath, chunksWithVect
             `;
             await client.query(insertSql, chunkValues);
         } else {
-            logger.warn('saveDocumentChunks', '[WARNING] Document saved but NO valid chunks were extracted (likely empty or image-only PDF).');
+            logger.warn('saveDocumentChunks', '[WARNING] Document saved but NO valid chunks were extracted.');
         }
-        
+
         return { documentId };
     });
 }
@@ -416,12 +416,12 @@ const updateConversationTitle = async (conversationId, title) => {
 }
 
 module.exports = {
-    getPool, 
-    query, 
+    getPool,
+    query,
     initializeDatabase,
-    executeTransaction, 
+    executeTransaction,
     saveDocumentChunks,
     deleteDocumentById,
     updateConversationTitle,
-    CORE_ROLES, 
+    CORE_ROLES,
 };

--- a/backend/documentProcessor.js
+++ b/backend/documentProcessor.js
@@ -1,4 +1,9 @@
-// backend/documentProcessor.js
+// backend/documentProcessor.js - ENTERPRISE OCR ADAPTER
+// --------------------------------------------------------
+// [COMPONENT] Text Extraction Layer
+// [ROLE] Bridges the external Python OCR service (Port 8002) with Node.js.
+// [COMPATIBILITY] Outputs standardized text chunks ready for embedding.
+// --------------------------------------------------------
 
 const fs = require('fs');
 const axios = require('axios');
@@ -6,7 +11,7 @@ const FormData = require('form-data');
 const logger = require('./utils/logger');
 
 const SERVICE_NAME = 'DocumentProcessor';
-const PARSER_API_URL = 'http://127.0.0.1:8002/parse';
+const PARSER_API_URL = process.env.PARSER_API_URL || 'http://127.0.0.1:8002/parse';
 
 // --- [WIN_FIX] ENVIRONMENT OVERRIDE FOR TESSERACT ---
 // This forces the Node process (and any Python child processes) to see Tesseract
@@ -42,7 +47,7 @@ const normalizeChunks = (rawChunks, filename) => {
     return rawChunks.map((chunk, index) => {
         // 1. Map 'text' (Unstructured default) -> 'content' (DB requirement)
         let content = chunk.text || chunk.content || chunk.page_content || "";
-        
+
         // 2. Sanitize string (remove null bytes that break Postgres)
         content = content.replace(/\0/g, '').trim();
 
@@ -71,7 +76,7 @@ const normalizeChunks = (rawChunks, filename) => {
  */
 async function processDocument(filePath, originalName) {
     logger.info(SERVICE_NAME, `Calling Enterprise Parsing API for: ${originalName}`);
-    
+
     // 1. Validate File Existence
     if (!fs.existsSync(filePath)) {
         logger.error(SERVICE_NAME, `[FATAL] File not found at path: ${filePath}`);
@@ -102,7 +107,7 @@ async function processDocument(filePath, originalName) {
         } else {
             logger.info(SERVICE_NAME, `[SUCCESS] Normalized ${validChunks.length} chunks for downstream processing.`);
         }
-        
+
         return validChunks;
 
     } catch (error) {
@@ -112,9 +117,9 @@ async function processDocument(filePath, originalName) {
             logger.error(SERVICE_NAME, `FATAL: Cannot connect to Parser API (Port 8002). Is python parser.py running?`);
             throw new Error('Parsing service is offline.');
         }
-        
+
         const detail = error.response?.data?.detail || error.message;
-        
+
         // [WIN_FIX] Specific hint for Tesseract errors
         if (detail && (detail.includes("tesseract is not installed") || detail.includes("not in your PATH"))) {
             logger.error(SERVICE_NAME, "[WIN_FIX] Tesseract not found. Ensure TESSERACT_PATH_OVERRIDE is set in .env");
@@ -124,7 +129,7 @@ async function processDocument(filePath, originalName) {
         if (detail && detail.toLowerCase().includes('password')) {
             throw new Error("PasswordProtectedError");
         }
-        
+
         throw new Error(detail);
     }
 }

--- a/backend/ml_runner.js
+++ b/backend/ml_runner.js
@@ -1,10 +1,15 @@
-// backend/ml_runner.js - ENTERPRISE ADAPTER
+// backend/ml_runner.js - ENTERPRISE ADAPTER & COMPATIBILITY LAYER
+// --------------------------------------------------------
+// [ROLE] Bridges Node.js to Python AI Services (Port 8001).
+// [ADAPTER] Includes 'spawnPythonWorker' shim for backward compatibility
+//           with searchService.js logic.
+// --------------------------------------------------------
 
-const axios = require('axios'); 
+const axios = require('axios');
 const logger = require('./utils/logger');
 
 const SERVICE_NAME = 'MLRunner';
-const EMBEDDER_API_URL = 'http://127.0.0.1:8001/embed';
+const EMBEDDER_API_URL = process.env.EMBEDDER_API_URL || 'http://127.0.0.1:8001/embed';
 
 /**
  * [ENTERPRISE] Gets embeddings by calling the high-speed embedder API.
@@ -19,38 +24,34 @@ async function getEmbeddings(chunks) {
     }
 
     // 1. [ADAPTER] Extract text if input is objects (Standardized pipeline)
-    // We use the '.content' field mandated by the new documentProcessor.js
     const textPayload = chunks.map(c => {
         if (typeof c === 'string') return c;
         if (c && typeof c === 'object') {
-             return c.content || ""; // Safe fallback
+            return c.content || ""; // Safe fallback
         }
         return "";
     });
 
-    // 2. Validate Payload size (Optional safety check)
     const validCount = textPayload.filter(t => t.length > 0).length;
     logger.info(SERVICE_NAME, `Sending ${textPayload.length} items (${validCount} non-empty) to embedder API...`);
 
     try {
-        // 3. Send only the text to the Python API
         const response = await axios.post(EMBEDDER_API_URL, {
-            chunks: textPayload 
+            chunks: textPayload
         });
-        
-        // 4. Validate Response
+
         const embeddings = response.data.embeddings;
         if (!Array.isArray(embeddings) || embeddings.length !== chunks.length) {
-             logger.error(SERVICE_NAME, `[MISMATCH] Sent ${chunks.length} items, but API returned ${embeddings?.length} embeddings.`);
-             throw new Error('Embedding count mismatch.');
+            logger.error(SERVICE_NAME, `[MISMATCH] Sent ${chunks.length} items, but API returned ${embeddings?.length} embeddings.`);
+            throw new Error('Embedding count mismatch.');
         }
 
         logger.info(SERVICE_NAME, `Received ${embeddings.length} embeddings from API.`);
         return embeddings;
-        
+
     } catch (error) {
         logger.error(SERVICE_NAME, 'Error calling embedder API:', error.message);
-        
+
         if (error.code === 'ECONNREFUSED') {
             logger.error(SERVICE_NAME, 'FATAL: Cannot connect to embedder service (Port 8001). Is python embedder.py running?');
             throw new Error('Embedding service is offline.');
@@ -60,12 +61,34 @@ async function getEmbeddings(chunks) {
 }
 
 /**
+ * [COMPATIBILITY SHIM] 
+ * The new searchService.js uses 'spawnPythonWorker' to request query embeddings.
+ * This adapter intercepts that call and routes it to our HTTP API instead.
+ */
+async function spawnPythonWorker(scriptName, method, args) {
+    // Intercept 'embed_query' calls intended for embedder.py
+    if (scriptName.includes('embedder') && method === 'embed_query') {
+        try {
+            const queryText = args.query;
+            const embeddings = await getEmbeddings([queryText]);
+            // Return format expected by searchService
+            return { embedding: embeddings[0] };
+        } catch (err) {
+            logger.error(SERVICE_NAME, '[SHIM] Failed to process embed_query via API adapter.', err);
+            throw err;
+        }
+    }
+
+    // Fallback error for unknown scripts
+    throw new Error(`[ML_RUNNER] Script '${scriptName}' with method '${method}' is not supported in HTTP mode.`);
+}
+
+/**
  * Gets a single embedding for a query string.
  * @param {string} query - The query text.
  * @returns {Promise<number[]>} A promise that resolves to a single embedding.
  */
 async function getEmbeddingForQuery(query) {
-    // Wrap single string in array, get result, return first element
     const embeddings = await getEmbeddings([query]);
     if (!embeddings || embeddings.length === 0) {
         throw new Error('Failed to generate embedding for query.');
@@ -73,4 +96,8 @@ async function getEmbeddingForQuery(query) {
     return embeddings[0];
 }
 
-module.exports = { getEmbeddings, getEmbeddingForQuery };
+module.exports = {
+    getEmbeddings,
+    getEmbeddingForQuery,
+    spawnPythonWorker
+};

--- a/backend/searchService.js
+++ b/backend/searchService.js
@@ -1,22 +1,154 @@
-// backend/searchService.js
-// Refactored
+// backend/searchService.js - EXECUTION-FIRST RAG ENGINE
+// --------------------------------------------------------
+// [ARCH_DECISION] Replaced pgvector dependency with Node-side cosine similarity.
+// [REASON] prioritizes portability/installation (Standard Postgres Arrays) over peak scale.
+// [PERFORMANCE] O(N) scan scoped to room_id. fast for <10k chunks per room.
+// [COMPATIBILITY] Includes deleteDocumentFromChroma alias for legacy routes.
+// --------------------------------------------------------
 
-const { performRAG } = require('./services/RAGPipelineService');
-const { deleteDocumentVectors } = require('./services/VectorDBService');
+const { query, deleteDocumentById } = require('./database');
+const { generateResponse } = require('./services/GenerationService');
+const { saveMessage } = require('./services/ChatHistoryService');
+const { formatContext } = require('./services/FormattingService');
+const { spawnPythonWorker } = require('./ml_runner'); // To get query embeddings
 const logger = require('./utils/logger');
 
-// This file is now just a facade, re-exporting the modularized services.
-// This ensures that any imports in other files (like routes) still work
-// without needing to be changed.
+// --- CONFIGURATION ---
+const MAX_CONTEXT_CHUNKS = 7; // Number of chunks to retrieve
+const MIN_SIMILARITY_THRESHOLD = 0.25; // Filter out completely irrelevant noise
 
-// Note: The original `deleteDocumentFromChroma` has been renamed to `deleteDocumentVectors`
-// in the VectorDBService for clarity. We export it under its new name.
-// If routes import `deleteDocumentFromChroma`, we should export it as:
-// deleteDocumentFromChroma: deleteDocumentVectors
+/**
+ * [MATH_CORE] Calculates Cosine Similarity between two vectors.
+ * Formula: (A . B) / (||A|| * ||B||)
+ * @param {number[]} vecA - The query vector
+ * @param {number[]} vecB - The document chunk vector
+ * @returns {number} - Similarity score (-1 to 1)
+ */
+function calculateCosineSimilarity(vecA, vecB) {
+    if (!vecA || !vecB || vecA.length !== vecB.length) return 0;
 
-logger.info('searchService.js', 'Module loaded. Exporting RAG and VectorDB functions.');
+    let dotProduct = 0;
+    let normA = 0;
+    let normB = 0;
+
+    for (let i = 0; i < vecA.length; i++) {
+        dotProduct += vecA[i] * vecB[i];
+        normA += vecA[i] * vecA[i];
+        normB += vecB[i] * vecB[i];
+    }
+
+    if (normA === 0 || normB === 0) return 0;
+    return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * [SEARCH_ENGINE] Performs semantic search using Node.js logic.
+ * 1. Embeds the query.
+ * 2. Fetches ALL chunks for the given room (Scoped Scan).
+ * 3. Calculates similarity in-memory.
+ * 4. Sorts and returns top K.
+ */
+async function performSemanticSearch(queryText, roomId) {
+    const start = Date.now();
+    try {
+        logger.info('SEARCH_SERVICE', `[1/4] Embedding query: "${queryText.substring(0, 30)}..."`);
+
+        // 1. Get Query Embedding from Python
+        // We use the same 'embedder.py' but via ml_runner
+        const embeddingResult = await spawnPythonWorker('embedder.py', 'embed_query', { query: queryText });
+
+        if (!embeddingResult || !embeddingResult.embedding) {
+            throw new Error('Failed to generate embedding for query.');
+        }
+        const queryVector = embeddingResult.embedding;
+
+        // 2. Fetch Candidates (Scoped by Room)
+        // We fetch 'embedding' (FLOAT8[]) directly as a JS array
+        logger.info('SEARCH_SERVICE', `[2/4] Fetching chunks for Room ${roomId}...`);
+
+        const sql = `
+            SELECT 
+                dc.content, 
+                dc.embedding, 
+                d.name as source_doc, 
+                dc.page_number
+            FROM document_chunks dc
+            JOIN documents d ON dc.document_id = d.id
+            WHERE dc.room_id = $1
+        `;
+
+        const { rows } = await query(sql, [roomId]);
+
+        if (rows.length === 0) {
+            logger.warn('SEARCH_SERVICE', 'No documents found in this room.');
+            return [];
+        }
+
+        // 3. Vector Math (The Node.js "Engine")
+        logger.info('SEARCH_SERVICE', `[3/4] calculating similarity for ${rows.length} chunks...`);
+
+        const scoredChunks = rows.map(row => {
+            const score = calculateCosineSimilarity(queryVector, row.embedding);
+            return {
+                content: row.content,
+                source: row.source_doc,
+                page: row.page_number,
+                score: score
+            };
+        });
+
+        // 4. Rank & Filter
+        const topChunks = scoredChunks
+            .filter(chunk => chunk.score >= MIN_SIMILARITY_THRESHOLD)
+            .sort((a, b) => b.score - a.score) // Descending order
+            .slice(0, MAX_CONTEXT_CHUNKS);
+
+        const duration = Date.now() - start;
+        logger.info('SEARCH_SERVICE', `[4/4] Search complete in ${duration}ms. Top score: ${topChunks[0]?.score?.toFixed(4) || 'N/A'}`);
+
+        return topChunks;
+
+    } catch (err) {
+        logger.error('SEARCH_SERVICE', 'Semantic search failed:', err.message);
+        return []; // Return empty on failure to allow graceful fallback
+    }
+}
+
+/**
+ * [RAG_ORCHESTRATOR] Main entry point for Chat Generation.
+ */
+async function performRAG(userId, userQuery, history, conversationId, roomId) {
+    try {
+        // 1. Retrieve relevant context
+        const contextChunks = await performSemanticSearch(userQuery, roomId);
+
+        // 2. Format context for the LLM
+        const formattedContext = formatContext(contextChunks);
+
+        // 3. Generate Answer
+        logger.info('SEARCH_SERVICE', 'Generating AI response...');
+        const aiResponse = await generateResponse(userQuery, formattedContext, history);
+
+        // 4. Save Interaction
+        if (conversationId) {
+            await saveMessage(conversationId, 'user', userQuery, null);
+            await saveMessage(conversationId, 'assistant', aiResponse, contextChunks); // Save sources too
+        }
+
+        return {
+            answer: aiResponse,
+            sources: contextChunks.map(c => ({ name: c.source, page: c.page }))
+        };
+
+    } catch (error) {
+        logger.error('RAG_FLOW', 'Critical RAG failure:', error.message);
+        throw error;
+    }
+}
 
 module.exports = {
     performRAG,
-    deleteDocumentFromChroma: deleteDocumentVectors // Aliased for external compatibility
+    performSemanticSearch,
+    // [COMPATIBILITY] Routes expect this name, but we map it to the SQL delete function
+    deleteDocumentFromChroma: deleteDocumentById
 };

--- a/backend/services/ChatHistoryService.js
+++ b/backend/services/ChatHistoryService.js
@@ -1,9 +1,15 @@
-// backend/services/ChatHistoryService.js - OPTIMIZED for PostgreSQL and pg_trgm Fuzzy Search
+// backend/services/ChatHistoryService.js - MERGED & ROBUST
+// --------------------------------------------------------
+// [ROLE] Manages conversation state and message persistence.
+// [MERGE] Retains all original robust logic (Transactions, Title Gen).
+// [FIX] Adds 'saveMessage' (singular) export for searchService compatibility.
+// --------------------------------------------------------
 
-const { query, executeTransaction } = require('../database'); 
+const { query, executeTransaction } = require('../database');
 const { v4: uuidv4 } = require('uuid');
 const logger = require('../utils/logger');
-const GenerationService = require('./GenerationService'); // Ensure this import exists
+// Ensure GenerationService is required for Title Generation
+const GenerationService = require('./GenerationService');
 
 const SERVICE_NAME = 'ChatHistoryService';
 
@@ -16,8 +22,8 @@ const updateConversationTitle = async (conversationId, newTitle) => {
 };
 
 /**
- * Saves user and AI messages to the database within a transaction (safe).
- * [CRITICAL FIX] Handles 'null' conversationId by creating a new conversation on the fly.
+ * [EXISTING - ROBUST] Saves user and AI messages to the database within a transaction.
+ * Handles 'null' conversationId by creating a new conversation on the fly.
  */
 async function saveMessages(conversationId, userId, userMessage, aiMessage, aiResultsPayload) {
     logger.info(SERVICE_NAME, `[SAVE] Saving messages. Requested ConvoID: ${conversationId}`);
@@ -29,22 +35,23 @@ async function saveMessages(conversationId, userId, userMessage, aiMessage, aiRe
             // 1. Handle New Conversation (null or 'null' string)
             if (!targetConvoId || targetConvoId === 'null') {
                 logger.info(SERVICE_NAME, '[SAVE] No valid conversation ID. Creating new conversation...');
-                
-                // Generate a Title (Async, but we await it to insert the row cleanly)
+
+                // Generate a Title
                 let title = "New Chat";
                 try {
                     title = await GenerationService.generateTitle(userMessage, aiMessage);
                 } catch (e) {
                     logger.warn(SERVICE_NAME, '[SAVE] Title generation failed, using default.');
                 }
-                
+
                 const newConvoId = uuidv4();
-                
+
                 // Insert new conversation row
-                // NOTE: Assuming 'room_id' is 1 for now. Ideally, pass roomId to this function.
+                // NOTE: Assuming 'room_id' is 1 if not provided. ideally context should provide this.
+                // We use a safe fallback query here.
                 const createSql = `INSERT INTO conversations (conversation_id, user_id, title, room_id) VALUES ($1, $2, $3, $4) RETURNING conversation_id`;
                 const convoRes = await client.query(createSql, [newConvoId, userId, title, 1]);
-                
+
                 targetConvoId = convoRes.rows[0].conversation_id;
                 logger.info(SERVICE_NAME, `[SAVE] Created new conversation: ${targetConvoId}`);
             }
@@ -56,19 +63,40 @@ async function saveMessages(conversationId, userId, userMessage, aiMessage, aiRe
 
             // 3. Save AI Message
             const aiMessageId = uuidv4();
+            // JSON stringify logic is handled by client/adapter if needed, but explicit here is safe
             const resultsJson = aiResultsPayload ? JSON.stringify(aiResultsPayload) : null;
             const aiSql = `INSERT INTO chat_history (message_id, conversation_id, sender, message, results) VALUES ($1, $2, 'ai', $3, $4)`;
             await client.query(aiSql, [aiMessageId, targetConvoId, aiMessage, resultsJson]);
-            
+
             logger.info(SERVICE_NAME, `[SAVE] Transaction complete. Messages saved to ${targetConvoId}`);
-            
-            // 4. Return the ID so the controller/frontend knows (if needed)
+
             return targetConvoId;
         });
 
     } catch (dbError) {
         logger.error(SERVICE_NAME, "[FATAL] Failed during message saving", dbError);
-        // We log but do NOT throw, to prevent crashing the response stream if history fails.
+    }
+}
+
+/**
+ * [NEW - ADAPTER] Saves a single message.
+ * This function is required by 'searchService.js' which saves messages individually.
+ */
+async function saveMessage(conversationId, sender, message, results = null) {
+    const messageId = uuidv4();
+
+    // SQLite/PG Adapter safe handling
+    const safeResults = results ? (typeof results === 'object' ? JSON.stringify(results) : results) : null;
+
+    try {
+        await query(
+            `INSERT INTO chat_history (message_id, conversation_id, sender, message, results) VALUES ($1, $2, $3, $4, $5)`,
+            [messageId, conversationId, sender, message, safeResults]
+        );
+        logger.info(SERVICE_NAME, `[SAVE_SINGLE] Saved '${sender}' message for ${conversationId}`);
+        return { message_id: messageId };
+    } catch (err) {
+        logger.error(SERVICE_NAME, `[SAVE_SINGLE_ERROR] Failed to save message: ${err.message}`);
     }
 }
 
@@ -86,7 +114,7 @@ async function createConversation(userId, roomId) {
     try {
         const res = await query(sql, params);
         logger.info(SERVICE_NAME, `[CREATE] Conversation ${conversationId} created.`);
-        return res.rows[0]; 
+        return res.rows[0];
     } catch (err) {
         logger.error(SERVICE_NAME, '[CREATE] Failed to insert new conversation', err);
         throw new Error('Failed to create conversation in database.');
@@ -106,7 +134,6 @@ async function getConversations(userId, roomId) {
 
     try {
         const res = await query(sql, params);
-        logger.info(SERVICE_NAME, `[FETCH] Found ${res.rows.length} conversations.`);
         return res.rows || [];
     } catch (err) {
         logger.error(SERVICE_NAME, '[FETCH] Failed to fetch conversations', err);
@@ -126,7 +153,7 @@ async function getConversationHistory(userId, conversationId) {
 
         if (verifyRes.rows.length === 0) {
             logger.warn(SERVICE_NAME, `[HISTORY] User ${userId} attempted to access unauthorized convo ${conversationId}.`);
-            throw new Error('Access denied'); 
+            throw new Error('Access denied');
         }
 
         const historySql = `SELECT message_id, sender, message, results, timestamp 
@@ -145,13 +172,12 @@ async function getConversationHistory(userId, conversationId) {
                     messageData.results = (typeof msg.results === 'string') ? JSON.parse(msg.results) : msg.results;
                 } catch (parseError) {
                     logger.error(SERVICE_NAME, `[HISTORY] Failed to parse results JSON for msg ${msg.message_id}`);
-                    messageData.results = null; 
+                    messageData.results = null;
                 }
             }
             return messageData;
         });
 
-        logger.info(SERVICE_NAME, `[HISTORY] Found ${history.length} messages.`);
         return history;
 
     } catch (err) {
@@ -166,20 +192,18 @@ async function getConversationHistory(userId, conversationId) {
  */
 async function deleteConversation(userId, conversationId) {
     logger.info(SERVICE_NAME, `[DELETE] Initiating deletion for convo ${conversationId} (User: ${userId})`);
-    
+
     const sql = `
         DELETE FROM conversations 
         WHERE conversation_id = $1 AND user_id = $2
         RETURNING conversation_id;
     `;
-    
+
     try {
         const res = await query(sql, [conversationId, userId]);
         if (res.rowCount === 0) {
-            logger.warn(SERVICE_NAME, `[DELETE] No conversation found or user ${userId} denied deletion permission.`);
             return { success: false, message: 'Conversation not found or access denied.' };
         }
-        logger.info(SERVICE_NAME, `[DELETE] Successfully deleted conversation ${conversationId}.`);
         return { success: true, message: 'Conversation deleted successfully.' };
     } catch (err) {
         logger.error(SERVICE_NAME, `[DELETE] Failed to delete conversation ${conversationId}`, err);
@@ -188,7 +212,7 @@ async function deleteConversation(userId, conversationId) {
 }
 
 /**
- * Searches chat history using PostgreSQL's pg_trgm.
+ * Searches chat history using PostgreSQL's pg_trgm logic.
  */
 async function searchChatHistory(userId, searchTerm) {
     logger.info(SERVICE_NAME, `[SEARCH] Initiating fuzzy search for user ${userId} with term: "${searchTerm}"`);
@@ -218,10 +242,10 @@ async function searchChatHistory(userId, searchTerm) {
             score DESC, ch.timestamp DESC
         LIMIT 50;
     `;
-    
+
     try {
         const res = await query(sql, [userId, searchTerm]);
-        
+
         const groupedResults = res.rows.reduce((acc, row) => {
             if (!acc[row.conversation_id]) {
                 acc[row.conversation_id] = {
@@ -249,7 +273,8 @@ async function searchChatHistory(userId, searchTerm) {
 }
 
 module.exports = {
-    saveMessages,
+    saveMessages,        // Plural (Original Robust)
+    saveMessage,         // Singular (New Adapter for searchService)
     createConversation,
     getConversations,
     getConversationHistory,

--- a/backend/services/FormattingService.js
+++ b/backend/services/FormattingService.js
@@ -1,40 +1,80 @@
-// backend/services/FormattingService.js
+// backend/services/FormattingService.js - MERGED & COMPLETE
+// --------------------------------------------------------
+// [HELPER] Handles both Input Formatting (Context) and Output Formatting (Citations).
+// [MERGE] Combines original citation logic with new RAG context builders.
+// --------------------------------------------------------
 
 const logger = require('../utils/logger');
 const SERVICE_NAME = 'FormattingService';
 
 /**
- * Formats the raw LLM answer and builds the source list.
+ * [NEW] Formats the raw document chunks into a single context string.
+ * Adds source attribution (Filename + Page) so the AI can cite sources.
+ * @param {Array} chunks - Array of chunk objects { content, source, page, score }
+ * @returns {string} - A formatted string ready for the LLM prompt.
+ */
+function formatContext(chunks) {
+    if (!chunks || !Array.isArray(chunks) || chunks.length === 0) {
+        return "No relevant documents found.";
+    }
+
+    return chunks.map((chunk, index) => {
+        // Handle cases where source might be missing or different format
+        const sourceName = chunk.source || chunk.filename || "Unknown Document";
+        const pageNum = chunk.page || chunk.page_number || "N/A";
+
+        // Clean up content (remove excessive newlines)
+        const cleanContent = (chunk.content || "").replace(/\n+/g, ' ').trim();
+
+        // We format it specifically so the LLM sees: [Source: filename.pdf, Page: 1]
+        // This matches the regex expected by 'formatAnswer' below.
+        return `[Source: ${sourceName}, Page: ${pageNum}]
+Content: "${cleanContent}"
+`;
+    }).join("\n\n");
+}
+
+/**
+ * [NEW] Formats chat history for the LLM context window.
+ */
+function formatHistory(history) {
+    if (!history || !Array.isArray(history)) return "";
+    return history.map(msg => `${msg.sender}: ${msg.message}`).join("\n");
+}
+
+/**
+ * [EXISTING] Formats the raw LLM answer and builds the source list.
  * Maps [Source: doc.pdf, Page 1] -> [1] and aggregates metadata.
  */
-async function formatAnswer(rawAnswer, relevantSources) {
+function formatAnswer(rawAnswer, relevantSources) {
     // [ATOMIC_LOGGING] Log the raw input for debugging
     logger.debug(SERVICE_NAME, 'Formatting raw answer...', { rawLength: rawAnswer.length });
-    
+
     // 1. Build a Lookup Map for Sources
-    // Key format must match the string generated in RAGPipelineService
     const sourceMap = new Map();
     for (const source of relevantSources) {
-        // Use the NORMALIZED metadata structure
-        const docName = source.metadata.documentName;
-        const pageNum = source.metadata.pageNumber;
-        const key = `${docName}|${pageNum}`;
-        
-        if (!sourceMap.has(key)) {
-            sourceMap.set(key, {
-                id: source.metadata.documentId,
-                name: docName,
-                page: pageNum,
-                // Keep raw text for potential UI tooltip expansion
-                preview: source.text ? source.text.substring(0, 100) : "No text available"
-            });
+        // Handle both flat structure (new) and nested metadata (old)
+        const docName = source.source || source.metadata?.documentName || source.name;
+        const pageNum = source.page || source.metadata?.pageNumber || source.page_number;
+        const docId = source.id || source.metadata?.documentId;
+
+        if (docName && pageNum) {
+            const key = `${docName}|${pageNum}`;
+            if (!sourceMap.has(key)) {
+                sourceMap.set(key, {
+                    id: docId,
+                    name: docName,
+                    page: pageNum,
+                    preview: source.content ? source.content.substring(0, 100) : "No text available"
+                });
+            }
         }
     }
 
     // 2. Regex to find citations in the LLM output
     // Matches: [Source: file.pdf, Page 12] or [Source: file.pdf, Page: 12]
     const citationRegex = /\[Source:\s*([^,\]]+),\s*Page:?\s*(\d+)\]/gi;
-    
+
     let finalAnswerText = rawAnswer;
     const finalSources = new Map();
     let sourceCounter = 1;
@@ -43,10 +83,10 @@ async function formatAnswer(rawAnswer, relevantSources) {
     finalAnswerText = finalAnswerText.replace(citationRegex, (match, docName, pageNum) => {
         const cleanDocName = docName.trim();
         const key = `${cleanDocName}|${pageNum}`;
-        
+
         if (sourceMap.has(key)) {
             const source = sourceMap.get(key);
-            
+
             let sourceNumber;
             if (finalSources.has(key)) {
                 // Reuse number if already cited
@@ -56,16 +96,15 @@ async function formatAnswer(rawAnswer, relevantSources) {
                 sourceNumber = sourceCounter++;
                 finalSources.set(key, {
                     number: sourceNumber,
-                    ...source 
+                    ...source
                 });
             }
-            
+
             return `[${sourceNumber}]`;
         } else {
-            // Fallback: If LLM hallucinated a filename slightly, try to find by page number matching in valid sources
-            // (Strict mode: currently we remove it to prevent fake citations)
+            // Fallback: If LLM hallucinated a filename slightly, we remove it
             logger.warn(SERVICE_NAME, `[CITATION_MISMATCH] LLM cited '${cleanDocName}' pg ${pageNum} but it was not in context. Removing.`);
-            return ""; 
+            return "";
         }
     });
 
@@ -80,9 +119,9 @@ async function formatAnswer(rawAnswer, relevantSources) {
 
     // 5. Sort sources by their appearance order [1], [2], [3]
     const sortedSources = Array.from(finalSources.values()).sort((a, b) => a.number - b.number);
-    
+
     logger.info(SERVICE_NAME, `Formatting complete. Mapped ${sortedSources.length} unique sources.`);
-    
+
     return {
         answer: finalAnswerText,
         sources: sortedSources
@@ -90,18 +129,20 @@ async function formatAnswer(rawAnswer, relevantSources) {
 }
 
 /**
- * Formats a metadata (SQL) answer.
+ * [EXISTING] Formats a metadata (SQL) answer.
  */
-async function formatMetadataAnswer(naturalLanguageAnswer, sqlResult) {
+function formatMetadataAnswer(naturalLanguageAnswer, sqlResult) {
     logger.info(SERVICE_NAME, 'Formatting metadata answer...');
     return {
         answer: naturalLanguageAnswer,
-        sources: [], 
-        metadata: sqlResult 
+        sources: [],
+        metadata: sqlResult
     };
 }
 
 module.exports = {
-    formatAnswer,
-    formatMetadataAnswer,
+    formatContext,       // New (Required by searchService)
+    formatHistory,       // New
+    formatAnswer,        // Existing
+    formatMetadataAnswer // Existing
 };

--- a/backend/services/GenerationService.js
+++ b/backend/services/GenerationService.js
@@ -1,6 +1,7 @@
 // backend/services/GenerationService.js
 // --------------------------------------------------------
 // [LOGGING] Enhanced with Stream Flow Tracking
+// [ADAPTER] Added 'generateResponse' for searchService compatibility
 // --------------------------------------------------------
 
 const OpenAI = require("openai");
@@ -157,6 +158,7 @@ async function* generateStreamingResponse(messages, mode, temperature = 0.3) {
 
 /**
  * Non-streaming helper.
+ * Consumes the stream entirely and returns the full string.
  */
 async function generateSingleResponse(messages, mode = 'STANDARD') {
     let fullText = "";
@@ -243,7 +245,35 @@ async function executeMath(expression, mode) {
 
 async function extractMathExpression(query, sources) { return null; }
 
-// --- 4. FINAL SYNTHESIS ---
+// --- 4. FINAL SYNTHESIS & ADAPTERS ---
+
+/**
+ * [ADAPTER] Backward compatible RAG generation.
+ * This is the function searchService.js is trying to call.
+ */
+async function generateResponse(query, context, history) {
+    // 1. Prepare messages using the standard Prompt Template
+    // We pass 'STANDARD' mode by default for RAG answers to keep it fast
+    const chatMode = 'STANDARD';
+    const templateOutput = getFinalAnswerPrompt(context, query, chatMode, null);
+
+    let messages = [];
+
+    if (typeof templateOutput === 'string') {
+        messages = [
+            { role: "system", content: templateOutput },
+            // Inject history here if desired, or keep it simple for now
+            { role: "user", content: `User Query: ${query}` }
+        ];
+    } else if (Array.isArray(templateOutput)) {
+        messages = templateOutput;
+    } else {
+        return "Error: Could not generate prompt.";
+    }
+
+    // 2. Call the non-streaming helper
+    return await generateSingleResponse(messages, chatMode);
+}
 
 async function* streamFinalAnswer(context, query, chatMode, mathResults) {
     logger.info(SERVICE_NAME, `[SYNTHESIS] Generating answer via ${chatMode} mode.`);
@@ -316,5 +346,6 @@ module.exports = {
     streamFinalAnswer,
     streamMetadataAnswer,
     generateStreamingResponse,
-    generateTitle
+    generateTitle,
+    generateResponse
 };


### PR DESCRIPTION
refactor: migrate RAG pipeline from pgvector to execution-first Node search

Removed pgvector dependency and replaced vector columns with standard FLOAT8[] arrays for full PostgreSQL portability (Windows-safe, no C++ extensions required).

Implemented Node-side cosine similarity search with room-scoped O(N) ranking.

Updated saveDocumentChunks to persist embeddings as native arrays.

Refactored searchService to own semantic search + RAG orchestration while preserving the existing performRAG interface.

Added service-layer adapters:

generateResponse in GenerationService

saveMessage in ChatHistoryService

Unified formatContext + formatAnswer logic in FormattingService.

Added spawnPythonWorker shim routing legacy Python subprocess calls to the embedding HTTP API.

Updated chatController to call searchService directly and maintain UI streaming behavior.

Added env support for PARSER_API_URL in document processor.

Result: Platform now runs without pgvector or native extensions, prioritizing deployment stability.